### PR TITLE
fix: Make player movement relative to camera

### DIFF
--- a/game.js
+++ b/game.js
@@ -48,17 +48,27 @@ window.addEventListener('DOMContentLoaded', function(){
 
         // Game/Render loop
         scene.onBeforeRenderObservable.add(() => {
+            var forward = camera.getDirection(BABYLON.Axis.Z);
+            var right = camera.getDirection(BABYLON.Axis.X);
+            var moveDirection = new BABYLON.Vector3(0, 0, 0);
+
             if (inputMap["w"] || inputMap["ArrowUp"]) {
-                sphere.position.z += 0.1;
+                moveDirection.addInPlace(forward);
             }
             if (inputMap["s"] || inputMap["ArrowDown"]) {
-                sphere.position.z -= 0.1;
+                moveDirection.subtractInPlace(forward);
             }
             if (inputMap["a"] || inputMap["ArrowLeft"]) {
-                sphere.position.x -= 0.1;
+                moveDirection.subtractInPlace(right);
             }
             if (inputMap["d"] || inputMap["ArrowRight"]) {
-                sphere.position.x += 0.1;
+                moveDirection.addInPlace(right);
+            }
+
+            if (moveDirection.length() > 0.01) {
+                moveDirection.y = 0; // Project to XZ plane
+                moveDirection.normalize();
+                sphere.position.addInPlace(moveDirection.scale(0.1));
             }
         });
 


### PR DESCRIPTION
This commit fixes the player movement controls to be relative to the camera's orientation. Previously, the controls were absolute to the world axes, which became unintuitive after implementing the ArcRotateCamera.

The movement logic now calculates a direction vector based on the camera's forward and right vectors, ensuring that pressing 'W' always moves the player forward from the camera's perspective.